### PR TITLE
also patch performance.measure

### DIFF
--- a/patch.js
+++ b/patch.js
@@ -1,7 +1,10 @@
 console.log('[FixChatGPTForFirefoxExtension] Performance API patch loaded');
 
 (function patchPerformanceMark() {
+
     try {
+
+        // This is the patch needed from 2025-05 for performance.mark
         if (window.wrappedJSObject && window.wrappedJSObject.performance) {
             const originalMark = window.wrappedJSObject.performance.mark;
 
@@ -20,14 +23,49 @@ console.log('[FixChatGPTForFirefoxExtension] Performance API patch loaded');
                 exportFunction(interceptedMark, window.wrappedJSObject.performance, { defineAs: 'mark' });
                 console.debug('[FixChatGPTForFirefoxExtension] exportFunction used to override performance.mark');
             } else {
-                // Fallback: directly assign interceptedMark if exportFunction is unavailable
                 window.wrappedJSObject.performance.mark = interceptedMark;
-                console.debug('[FixChatGPTForFirefoxExtension] exportFunction not available; attempting ro directly assigned interceptedMark');
+                console.debug('[FixChatGPTForFirefoxExtension] exportFunction not available; attempted direct assignment');
             }
         } else {
             console.error('[FixChatGPTForFirefoxExtension] wrappedJSObject or performance not available.');
         }
+
+        // This is the patch needed from 2025-12 for performance.measure
+        if (window.wrappedJSObject && window.wrappedJSObject.performance) {
+            const originalMeasure = window.wrappedJSObject.performance.measure;
+
+            const interceptedMeasure = function (measureName, measureOptions) {
+                console.debug('[FixChatGPTForFirefoxExtension] performance.measure called', measureName, measureOptions);
+
+                if (measureOptions && typeof measureOptions.start === 'number' && measureOptions.start < 0) {
+                    console.warn('[FixChatGPTForFirefoxExtension] performance.measure called with negative start', measureOptions, 'converting to 0');
+                    measureOptions.start = 0;
+                }
+                if (measureOptions && typeof measureOptions.end === 'number' && measureOptions.end < 0) {
+                    console.warn('[FixChatGPTForFirefoxExtension] performance.measure called with negative end', measureOptions, 'converting to 0');
+                    measureOptions.end = 0;
+                }
+
+                return originalMeasure.call(window.wrappedJSObject.performance, measureName, measureOptions);
+            };
+
+            if (typeof exportFunction === 'function') {
+                exportFunction(interceptedMeasure, window.wrappedJSObject.performance, { defineAs: 'measure' });
+                console.debug('[FixChatGPTForFirefoxExtension] exportFunction used to override performance.measure');
+            } else {
+                window.wrappedJSObject.performance.measure = interceptedMeasure;
+                console.debug('[FixChatGPTForFirefoxExtension] exportFunction not available; attempted direct assignment');
+            }
+        } else {
+            console.error('[FixChatGPTForFirefoxExtension] wrappedJSObject or performance not available.');
+        }
+
+
+
+
     } catch (e) {
         console.error('[FixChatGPTForFirefoxExtension] Failed to override performance.mark:', e);
     }
+
 })();
+


### PR DESCRIPTION
Like performance.mark, chatGPT has started using performance.measure and sometimes providing it negative values.